### PR TITLE
Restrict validation to result files

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,2 +1,14 @@
+/**
+ * Copyright 2020 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 export const testSubjects = ['rollup', 'webpack', 'parcel', 'gulp'];
 export const githubRepository = 'https://github.com/GoogleChromeLabs/buildoff/';

--- a/lib/markdown-validator.js
+++ b/lib/markdown-validator.js
@@ -10,11 +10,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { testSubjects } from '../config';
 
 const validResults = new Set(['pass', 'fail', 'partial']);
+const resultIdEnds = testSubjects.map(t => `/${t}/index.md`);
 
 export default function validateMarkdownData(id, data) {
   if (!id.startsWith('tests/')) return;
+  if (!resultIdEnds.some(resultIdEnd => id.endsWith(resultIdEnd))) {
+    return;
+  }
+
+  if (!('result' in data)) {
+    this.warn(`Missing result data in ${id}`);
+  }
 
   if ('result' in data && !validResults.has(data.result)) {
     throw Error(


### PR DESCRIPTION
Previously it was complaining about missing issues in our test explanation files.