### PR TITLE
Fixing watch

### DIFF
--- a/lib/css-plugin.js
+++ b/lib/css-plugin.js
@@ -129,11 +129,20 @@ export default function() {
               `export const $${camelCase(key)} = ${JSON.stringify(val)};`,
           );
 
-          const defs = Object.keys(moduleJSON).map(
-            key => `export const $${camelCase(key)}: string;`,
-          );
+          const defs = Object.keys(moduleJSON)
+            .map(key => `export const $${camelCase(key)}: string;`)
+            .join('\n');
 
-          await fsp.writeFile(path + '.d.ts', defs.join('\n'));
+          const defPath = path + '.d.ts';
+          const currentDefFileContent = await fsp
+            .readFile(defPath, { encoding: 'utf8' })
+            .catch(() => undefined);
+
+          // Only write the file if contents have changed, otherwise it causes a loop with
+          // TypeScript's file watcher.
+          if (defs !== currentDefFileContent) {
+            await fsp.writeFile(defPath, defs);
+          }
 
           pathToResult.set(path, {
             module: cssClassExports.join('\n'),

--- a/lib/simple-ts.js
+++ b/lib/simple-ts.js
@@ -43,36 +43,44 @@ export default function simpleTS(mainPath, { noBuild, watch } = {}) {
 
   let tsBuildDone;
 
-  function tsBuild(rollupContext) {
-    if (tsBuildDone) return tsBuildDone;
+  async function watchBuiltFiles(rollupContext) {
+    const matches = await globP(config.options.outDir + '/**/*.js');
+    for (const match of matches) rollupContext.addWatchFile(match);
+  }
+
+  async function tsBuild(rollupContext) {
+    if (tsBuildDone) {
+      // Watch lists are cleared on each build, so we need to rewatch all the JS files.
+      await watchBuiltFiles(rollupContext);
+      return tsBuildDone;
+    }
     if (noBuild) {
       return (tsBuildDone = Promise.resolve());
     }
-    tsBuildDone = new Promise(resolve => {
-      const proc = spawn('tsc', args, {
-        stdio: 'inherit',
-      });
-
-      proc.on('exit', code => {
-        if (code !== 0) {
-          throw Error('TypeScript build failed');
-        }
-        resolve();
-      });
-    });
-
-    tsBuildDone.then(async () => {
-      const matches = await globP(config.options.outDir + '/**/*.js');
-      for (const match of matches) rollupContext.addWatchFile(match);
-    });
-
-    if (watch) {
-      tsBuildDone.then(() => {
-        spawn('tsc', [...args, '--watch', '--preserveWatchOutput'], {
+    tsBuildDone = Promise.resolve().then(async () => {
+      await new Promise(resolve => {
+        const proc = spawn('tsc', args, {
           stdio: 'inherit',
         });
+
+        proc.on('exit', code => {
+          if (code !== 0) {
+            throw Error('TypeScript build failed');
+          }
+          resolve();
+        });
       });
-    }
+
+      await watchBuiltFiles(rollupContext);
+
+      if (watch) {
+        tsBuildDone.then(() => {
+          spawn('tsc', [...args, '--watch', '--preserveWatchOutput'], {
+            stdio: 'inherit',
+          });
+        });
+      }
+    });
 
     return tsBuildDone;
   }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -53,7 +53,8 @@ export default async function({ watch }) {
       assetFileNames: staticPath,
       exports: 'named',
     },
-    watch: { clearScreen: false },
+    // Don't watch the ts files. Instead we watch the output from the ts compiler.
+    watch: { clearScreen: false, exclude: ['**/*.ts', '**/*.tsx'] },
     preserveModules: true,
     plugins: [
       { resolveFileUrl },


### PR DESCRIPTION
Fixes #54.

The problem:

1. CSS plugin wrote `.d.ts` files for the CSS.
1. TS's watcher saw this and restarted its build.
1. Rollup's watcher saw JS change, and restarted its build.
1. GOTO 1.

Interestingly, neither watcher checks if the file content changes.