### PR TITLE
Fix GitHub links

### DIFF
--- a/static-build/utils.tsx
+++ b/static-build/utils.tsx
@@ -21,7 +21,7 @@ import { VNode } from 'preact';
 import config from 'consts:config';
 
 export function githubLink(filePath: string, ref: string = 'master') {
-  return joinPath(config.githubRepository, 'tree', ref, filePath);
+  return `${config.githubRepository}tree/${ref}/${filePath}`;
 }
 
 export function renderPage(vnode: VNode) {


### PR DESCRIPTION
path.join() does not handle protocols, best not to use it here:

```sh
> require('path').join('https://github.com/foo/bar/', 'baz', 'bat')
'https:/github.com/foo/bar/baz/bat'
     ^^^
```