### PR TITLE
Deploy live branch instead of master

### DIFF
--- a/.github/workflows/live-deploy.yml
+++ b/.github/workflows/live-deploy.yml
@@ -1,12 +1,12 @@
-name: Master Deploy
+name: Live Deploy
 on:
   push:
     branches:
-      - master
+      - live
 
 jobs:
-  master-deploy:
-    name: Master Deploy
+  live-deploy:
+    name: Live Deploy
     runs-on: ubuntu-latest
     env:
       CI: true


### PR DESCRIPTION
CLoses #190 

This means we currently don’t have a way to access a build of `master`, but we can fix that in a separate PR as it’s less urgent.