### PR TITLE
[bugfix] Shadow Overlap on Subtest Cards

### DIFF
--- a/static-build/components/TestCard/styles.css
+++ b/static-build/components/TestCard/styles.css
@@ -59,6 +59,8 @@
 
 .subTestCard {
   position: relative;
+  will-change: box-shadow;
+  transform-style: preserve-3d;
 
   &::after,
   &::before {


### PR DESCRIPTION
Adds preserve-3d transform on card to prevent shadow leakage (+ a will-change for perf)

Resolves #203