### PR TITLE
Grid dot enhancement

### DIFF
--- a/static-build/components/DataGrid/styles.css
+++ b/static-build/components/DataGrid/styles.css
@@ -73,6 +73,8 @@
       50%,
       var(--test-partial),
       51%,
+      white,
+      52%,
       white
     );
     border-color: var(--test-partial);


### PR DESCRIPTION
<img width="366" alt="Screen Shot 2020-04-28 at 2 42 02 PM" src="https://user-images.githubusercontent.com/1134620/80540565-702ab680-895e-11ea-9deb-c3bda2db2043.png">

<img width="1200" alt="Screen Shot 2020-04-28 at 2 41 04 PM" src="https://user-images.githubusercontent.com/1134620/80540484-4d000700-895e-11ea-94e3-46285d678854.png">

goal was to communicate state without just color. i accomplished it here with just css, no new svg or icons. thoughts? 