### PR TITLE
Align summary items

### DIFF
--- a/static-build/pages/test/detail.css
+++ b/static-build/pages/test/detail.css
@@ -124,12 +124,17 @@ value means Firefox won't render the arrow */
 
 .subjectName {
   display: inline-block;
-  margin: 0 var(--spacing-2) 0 var(--spacing-4);
+  margin-right: var(--spacing-2);
   font-weight: bold;
 }
 
-details .subjectName {
-  margin: 0 var(--spacing-2);
+.subjectContainer {
+  position: absolute;
+  display: flex;
+  left: var(--spacing-6);
+  top: 0;
+  align-items: center;
+  padding: 10px 0;
 }
 
 .resultsCard {

--- a/static-build/pages/test/index.tsx
+++ b/static-build/pages/test/index.tsx
@@ -37,6 +37,7 @@ import {
   $gitHubIconPlaceholder,
   $gitHubIcon,
   $resultSummaryInner,
+  $subjectContainer,
 } from './detail.css';
 import {
   $collectionPage,
@@ -138,8 +139,10 @@ const TestPage: FunctionalComponent<Props> = ({ test }: Props) => {
                 {Object.entries(test.results).map(([subject, result]) => {
                   const summaryInner = (
                     <div class={$resultSummaryInner}>
-                      <span class={$subjectName}>{subject}</span>
-                      <Dot result={result.meta.result} />
+                      <div class={$subjectContainer}>
+                        <span class={$subjectName}>{subject}</span>
+                        <Dot result={result.meta.result} />
+                      </div>
                       <div class={$gitHubIconPlaceholder} />
                     </div>
                   );


### PR DESCRIPTION
Mentioned in #289 -- @surma 

Fixes alignment in Summary (also adds a tiny bit of additional breathing room between arrow and text)

<img width="812" alt="Screen Shot 2020-05-21 at 10 54 16 AM" src="https://user-images.githubusercontent.com/1693164/82572325-2e9ebd00-9b52-11ea-88a4-b9ef79b6c109.png">
<img width="372" alt="Screen Shot 2020-05-21 at 10 54 10 AM" src="https://user-images.githubusercontent.com/1693164/82572327-2e9ebd00-9b52-11ea-8ef3-bd1569ada0b5.png">
