### PR TITLE
fixes dark mode syntax highlighting

### DIFF
--- a/static-build/libraries/prism/prism.css
+++ b/static-build/libraries/prism/prism.css
@@ -61,12 +61,12 @@
 
   .token.string,
   .token.attr-value {
-    color: #e3116c;
+    color: var(--syntax-pink);
   }
 
   .token.punctuation,
   .token.operator {
-    color: #393a34; /* no highlight */
+    color: var(--syntax-puncation); /* no highlight */
   }
 
   .token.entity,
@@ -92,13 +92,7 @@
   .token.function,
   .token.deleted,
   .language-autohotkey .token.tag {
-    color: #950d80; /* var(--grape) ala #156 */
-  }
-
-  .token.tag,
-  .token.selector,
-  .language-autohotkey .token.keyword {
-    color: #00009f;
+    color: var(--grape);
   }
 
   .token.important,

--- a/static-build/shared/styles/colors.css
+++ b/static-build/shared/styles/colors.css
@@ -39,6 +39,10 @@
     0 100px 20px hsl(var(--denim-blue-hsl) / 6%);
   --fab-shadow: 0 5px 10px hsl(var(--denim-blue-hsl) / 20%);
 
+  /* Syntax */
+  --syntax-pink: hsl(334 86% 48%);
+  --syntax-puncation: hsl(70 5% 22%);
+
   @media (prefers-color-scheme: dark) {
     --ice-blue: hsl(206 50% 8%);
     --light-blue: hsl(206 20% 17%);
@@ -49,7 +53,7 @@
     --backpack-blue: hsl(206 30% 70%);
     --denim-blue: hsl(206 36% 51%);
 
-    --grape: hsl(309 84% 32%);
+    --grape: hsl(309 45% 60%);
 
     --test-pass: hsl(111 27% 62%);
     --test-pass--text: hsl(111 27% 52%);
@@ -69,5 +73,8 @@
     --card-shadow: none;
     --card-shadow--active: none;
     --fab-shadow: none;
+
+    --syntax-pink: hsl(334 65% 80%);
+    --syntax-puncation: hsl(70 5% 80%);
   }
 }


### PR DESCRIPTION
<details>

<summary>old</summary>

<img width="516" alt="Screen Shot 2020-06-22 at 9 55 43 AM" src="https://user-images.githubusercontent.com/1134620/85314610-9b1d1c80-b46e-11ea-9cca-a2a1249e51e0.png">

</details>

<details>

<summary>new</summary>

<img width="493" alt="Screen Shot 2020-06-22 at 9 53 31 AM" src="https://user-images.githubusercontent.com/1134620/85314647-a83a0b80-b46e-11ea-95e5-5f3c9a3ed74c.png">

</details>

@surma found it 👍 