### PR TITLE
Font rendering fix

### DIFF
--- a/static-build/components/HeadMeta/index.tsx
+++ b/static-build/components/HeadMeta/index.tsx
@@ -34,12 +34,6 @@ export default function HeadMeta() {
       <link rel="mask-icon" href={safariURL} />
       <meta name="color-scheme" content="dark light" />
       <SocialMeta />
-      <script>{`
-        const ua = navigator.userAgent;
-        if (ua.includes('Windows') && ua.includes('Chrome')) {
-          document.documentElement.style.setProperty('--font-weight--light', '400');
-        }
-      `}</script>
       <link rel="stylesheet" href={sharedStyles} />
     </Fragment>
   );

--- a/static-build/shared/styles/typography.css
+++ b/static-build/shared/styles/typography.css
@@ -1,6 +1,6 @@
 :root {
-  --font-body: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
-    Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  --font-body: -apple-system, BlinkMacSystemFont, Roboto, Oxygen, Ubuntu,
+    Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
 
   --font-lineheight--body: 1.5;
   --font-lineheight--extended: 2;


### PR DESCRIPTION
This reverts commit a446241c4156d6db6327dd3f0f7d66cfa9d3ab88.

Right now it's just throwing an error on live. I'll take a look at a fix after this is live.

I think I've found a better solution for the fonts. "Sergoe" was just too light compared to the other defaults, so I've removed it from the font list.