### PR TITLE
Removed plugin rollup cjs as it is not used in the esm test

### DIFF
--- a/tests/importing-modules/subtests/es-modules/rollup/package.json
+++ b/tests/importing-modules/subtests/es-modules/rollup/package.json
@@ -4,7 +4,6 @@
     "build": "rm -rf build && rollup -c"
   },
   "devDependencies": {
-    "@rollup/plugin-commonjs": "^11.0.2",
     "rollup": "^2.0.2"
   }
 }

--- a/tests/importing-modules/subtests/es-modules/rollup/rollup.config.js
+++ b/tests/importing-modules/subtests/es-modules/rollup/rollup.config.js
@@ -10,11 +10,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import commonjs from '@rollup/plugin-commonjs';
 
 export default {
   input: `src/index.js`,
-  plugins: [commonjs()],
+  plugins: [],
   output: {
     dir: 'build',
     format: 'esm',


### PR DESCRIPTION
Removed plugin rollup cjs as it is not used in the esm test