### PR TITLE
Move link inside to avoid phantom links

### DIFF
--- a/static-build/pages/index/index.tsx
+++ b/static-build/pages/index/index.tsx
@@ -154,12 +154,12 @@ const IndexPage: FunctionalComponent<Props> = ({ tests }: Props) => {
             </section>
 
             <section id="summary">
-              <a href="#summary" class={$summaryHeader}>
-                <h3 class={$sectionHeader}>
+              <h3 class={$sectionHeader}>
+                <a href="#summary" class={$summaryHeader}>
                   <span class={$sectionHashtag}>#</span>
                   Summary
-                </h3>
-              </a>
+                </a>
+              </h3>
               <div class={$sidebarLayout}>
                 <aside>
                   <small>
@@ -198,15 +198,15 @@ const IndexPage: FunctionalComponent<Props> = ({ tests }: Props) => {
           <div class={$overviewContainer}>
             <section class={`${$contentContainer} ${$overviewContent}`}>
               <div class={$overviewGrid}>
-                <a href="#overview">
-                  <h2
+                <h2
                     id="overview"
                     class={`${$overviewHeader} ${$sectionHeader}`}
                   >
+                  <a href="#overview">
                     <span class={$sectionHashtag}>#</span>
                     Overview
-                  </h2>
-                </a>
+                  </a>
+                </h2>
                 <DataGrid
                   tests={tests}
                   basePath="/"


### PR DESCRIPTION
Currently there are phantom interactive areas on the page:

![before](https://user-images.githubusercontent.com/105274/86512398-bbec5700-be0a-11ea-8fca-f971539a31cf.png)

Which makes interface less predictable. When you click on the top right corner of this yellow box, you probably have no idea that it’s related to the header on the left side and what’s going to happen.

![after](https://user-images.githubusercontent.com/105274/86512429-f2c26d00-be0a-11ea-968b-cae1b1c3720c.png)

By having the link inside, you can limit its interactive area.

It’s probably not the only place where titles are wrapped with links, but that’s a start.