### PR TITLE
fixes shadows

### DIFF
--- a/static-build/shared/styles/colors.css
+++ b/static-build/shared/styles/colors.css
@@ -28,7 +28,7 @@
   --text-gray: hsl(0, 0%, 10%);
 
   /* Shadows */
-  --denim-blue-hsl: 206, 36%, 51%;
+  --denim-blue-hsl: 206 36% 51%;
   --card-shadow: 0 8px 2px hsl(var(--denim-blue-hsl) / 2%),
     0 25px 10px hsl(var(--denim-blue-hsl) / 7%),
     0 50px 10px hsl(var(--denim-blue-hsl) / 5%),


### PR DESCRIPTION
I just realized I regressed the deep shadows styles when resolving the previous IE regression. Here's a PR to restore it 😬  

This restores shadows for all functional color notation supporting browsers, but does have them missing for browsers that don't support it. Feels like a reasonable trade to me. Thoughts?

<details>

<summary>before (no shadow due to syntax error)</summary>

<img width="1302" alt="Screen Shot 2020-07-17 at 11 41 27 AM" src="https://user-images.githubusercontent.com/1134620/87820178-78d6ae80-c822-11ea-9f35-e4a40214dbcb.png">


</details>




<details>

<summary>after</summary>

<img width="1288" alt="Screen Shot 2020-07-17 at 11 41 09 AM" src="https://user-images.githubusercontent.com/1134620/87820186-7ecc8f80-c822-11ea-9a62-ed37f056bba0.png">


</details>