### PR TITLE
Update outdated content

### DIFF
--- a/tests/code-splitting/subtests/multi-entry/webpack/index.md
+++ b/tests/code-splitting/subtests/multi-entry/webpack/index.md
@@ -6,7 +6,7 @@ When you opt-in to code splitting, Webpack may duplicate modules between chunks 
 
 However, you can set [`optimization.runtimeChunk`][runtimechunk] to `"single"`. This moves Webpack's runtime module loader into its own bundle rather than being inlined into each entry, creating a global registry that allows code-splitted modules to be shared between entries. This doesn't prevent Webpack from copying module code between entry points, but it prevents it creating two instances of the same module at runtime, while reducing the number of HTTP requests needed to load modules for a given page.
 
-This test is a "partial" pass, since `runtimeChunk:"single"` is required to ensure correct module instantiation, but it is disabled by default and not documented in [Webpack's code splitting guide](https://webpack.js.org/guides/code-splitting/).
+This test is a "partial" pass, since `runtimeChunk:"single"` is required to ensure correct module instantiation, but it is disabled by default.
 
 The [`optimization.splitChunks.minSize` option](https://webpack.js.org/plugins/split-chunks-plugin/#splitchunksminsize) can be used to change the size threshold for creating a chunk, which defaults to 30k.
 


### PR DESCRIPTION
It's documented in code splitting guide now https://webpack.js.org/guides/code-splitting/#entry-dependencies:

![image](https://user-images.githubusercontent.com/1091472/99393393-3cbe7200-2918-11eb-994f-d3ddb3fb0774.png)
