### PR TITLE
Revert will-change in favor of an alternative visually-hidden style

### DIFF
--- a/static-build/components/TestCard/styles.css
+++ b/static-build/components/TestCard/styles.css
@@ -153,13 +153,9 @@
 
 /* visually hide bundler names */
 .iconList figcaption {
-  clip: rect(0 0 0 0);
-  clip-path: inset(50%);
-  height: 1px;
-  width: 1px;
+  width: 0;
+  height: 0;
   overflow: hidden;
-  position: absolute;
-  white-space: nowrap;
 }
 
 .testCardIcon {

--- a/static-build/components/TestCard/styles.css
+++ b/static-build/components/TestCard/styles.css
@@ -17,7 +17,7 @@
     justify-content: center;
     width: 100%;
     transition: 0.2s ease-in-out;
-    will-change: box-shadow, transform;
+    will-change: box-shadow;
     transform-style: preserve-3d;
     position: relative;
 
@@ -153,9 +153,13 @@
 
 /* visually hide bundler names */
 .iconList figcaption {
-  width: 0;
-  height: 0;
-  text-indent: -99999999px;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
 }
 
 .testCardIcon {

--- a/static-build/components/TestCard/styles.css
+++ b/static-build/components/TestCard/styles.css
@@ -17,7 +17,7 @@
     justify-content: center;
     width: 100%;
     transition: 0.2s ease-in-out;
-    will-change: box-shadow;
+    will-change: box-shadow, transform;
     transform-style: preserve-3d;
     position: relative;
 


### PR DESCRIPTION
see Chromium bug we made the patch for and are now updating our patch to a better solution https://bugs.chromium.org/p/chromium/issues/detail?id=1170365#c9

tldr; swap text-indent for clip-path