### PR TITLE
Add issue URL to Webpack dynamic import

### DIFF
--- a/tests/code-splitting/subtests/splitting-modules/subtests/dynamic-import/webpack/index.md
+++ b/tests/code-splitting/subtests/splitting-modules/subtests/dynamic-import/webpack/index.md
@@ -1,5 +1,6 @@
 ---
 result: fail
+issue: https://github.com/webpack/webpack/issues/7782
 ---
 
 Webpack inlines the common `objects.js` module as-is into the entry bundle, and the lazy bundle references that copy. While this is a very reasonable behavior, the ideal behavior would have been to "pull apart" the exports of `objects.js` so they can be used independently. No currently tested bundlers pass this test.


### PR DESCRIPTION
Adds issue https://github.com/webpack/webpack/issues/7782 to the dynamic import test for Webpack. I'm not 100% sure that this is the same problem/scope, please verify.