### PR TITLE
Parcel: inline scripts and transpilation

### DIFF
--- a/tests/non-js-resources/subtests/html/subtests/inlining-scripts/parcel/index.md
+++ b/tests/non-js-resources/subtests/html/subtests/inlining-scripts/parcel/index.md
@@ -1,18 +1,14 @@
 ---
-result: partial
+result: pass
 issue:
   - url: https://github.com/parcel-bundler/website/issues/629
+    status: closed
   - url: https://github.com/parcel-bundler/parcel/issues/4855
+    fixedSince: 2.0.0-beta.2
+    status: closed
 ---
 
-Parcel has an undocumented way to do this:
-
-```html
-<!DOCTYPE html>
-<script src="whatever.js"></script>
-```
-
-The above will result in a separate resource for the script. However:
+Putting JavaScript inside of a `<script>` tag will also [inline the resulting bundle into the HTML file](https://v2.parceljs.org/languages/html/#inline-script-and-style-tags):
 
 ```html
 <!DOCTYPE html>
@@ -20,7 +16,3 @@ The above will result in a separate resource for the script. However:
   import './whatever.js';
 </script>
 ```
-
-The above will _inline_ the script into the page.
-
-However, this creates inline sourcemaps in your code, which will inflate the size of your JavaScript in production. The only way to avoid this is to disable sourcemaps altogether.

--- a/tests/non-js-resources/subtests/html/subtests/inlining-scripts/parcel/package.json
+++ b/tests/non-js-resources/subtests/html/subtests/inlining-scripts/parcel/package.json
@@ -3,8 +3,6 @@
     "build": "rm -rf .parcel-cache && parcel build src/index.html src/profile.html"
   },
   "dependencies": {
-    "@babel/core": "^7.12.0",
-    "parcel": "^2.0.0-beta.2",
-    "postcss": "^8.2.1"
+    "parcel": "2.0.0-rc.0"
   }
 }

--- a/tests/non-js-resources/subtests/html/subtests/inlining-scripts/parcel/package.json
+++ b/tests/non-js-resources/subtests/html/subtests/inlining-scripts/parcel/package.json
@@ -3,6 +3,8 @@
     "build": "rm -rf .parcel-cache && parcel build src/index.html src/profile.html"
   },
   "dependencies": {
-    "parcel": "2.0.0-beta.1"
+    "@babel/core": "^7.12.0",
+    "parcel": "^2.0.0-beta.2",
+    "postcss": "^8.2.1"
   }
 }

--- a/tests/transformations/subtests/transpile-js/parcel/.babelrc
+++ b/tests/transformations/subtests/transpile-js/parcel/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["@parcel/babel-preset-env"],
+  "plugins": ["@parcel/babel-plugin-transform-runtime"]
+}

--- a/tests/transformations/subtests/transpile-js/parcel/.babelrc
+++ b/tests/transformations/subtests/transpile-js/parcel/.babelrc
@@ -1,4 +1,0 @@
-{
-  "presets": ["@parcel/babel-preset-env"],
-  "plugins": ["@parcel/babel-plugin-transform-runtime"]
-}

--- a/tests/transformations/subtests/transpile-js/parcel/index.md
+++ b/tests/transformations/subtests/transpile-js/parcel/index.md
@@ -2,4 +2,4 @@
 result: pass
 ---
 
-ES5 is the default in Parcel.
+By default, Parcel doesn't transpile. Setting a browserslist config (i.e. in `package.json#browserslist`) will enable transpilation to support the specified browsers (though for await/async, [another Babel plugin has to be specified](https://v2.parceljs.org/languages/babel/#extending-the-default-babel-config)).

--- a/tests/transformations/subtests/transpile-js/parcel/index.md
+++ b/tests/transformations/subtests/transpile-js/parcel/index.md
@@ -2,4 +2,4 @@
 result: pass
 ---
 
-By default, Parcel doesn't transpile. Setting a browserslist config (i.e. in `package.json#browserslist`) will enable transpilation to support the specified browsers (though for await/async, [another Babel plugin has to be specified](https://v2.parceljs.org/languages/babel/#extending-the-default-babel-config)).
+By default, Parcel doesn't transpile. Setting a browserslist config (i.e. in `package.json#browserslist`) will enable transpilation to support the specified browsers.

--- a/tests/transformations/subtests/transpile-js/parcel/package.json
+++ b/tests/transformations/subtests/transpile-js/parcel/package.json
@@ -3,11 +3,7 @@
     "build": "rm -rf .parcel-cache && parcel build src/index.js"
   },
   "dependencies": {
-    "@babel/core": "^7.12.0",
-    "@parcel/babel-plugin-transform-runtime": "^2.0.0-beta.2",
-    "@parcel/babel-preset-env": "^2.0.0-beta.2",
-    "parcel": "^2.0.0-beta.2",
-    "postcss": "^8.2.1"
+    "parcel": "2.0.0-rc.0"
   },
   "browserslist": [
     "Safari 9"

--- a/tests/transformations/subtests/transpile-js/parcel/package.json
+++ b/tests/transformations/subtests/transpile-js/parcel/package.json
@@ -3,6 +3,13 @@
     "build": "rm -rf .parcel-cache && parcel build src/index.js"
   },
   "dependencies": {
-    "parcel": "^2.0.0-alpha.3.2"
-  }
+    "@babel/core": "^7.12.0",
+    "@parcel/babel-plugin-transform-runtime": "^2.0.0-beta.2",
+    "@parcel/babel-preset-env": "^2.0.0-beta.2",
+    "parcel": "^2.0.0-beta.2",
+    "postcss": "^8.2.1"
+  },
+  "browserslist": [
+    "Safari 9"
+  ]
 }


### PR DESCRIPTION
- Inline scripts are now documented/fixed
- in beta 2, Parcel doesn't transpile to ES5 anymore by default. A browserslist config should be specified