### PR TITLE
Parcel passes the code-splitting/multi-entry test now

### DIFF
--- a/tests/code-splitting/subtests/multi-entry/parcel/index.md
+++ b/tests/code-splitting/subtests/multi-entry/parcel/index.md
@@ -1,6 +1,6 @@
 ---
-result: fail
+result: pass
 issue: https://github.com/parcel-bundler/parcel/issues/4302
 ---
 
-Parcel inlines `obj.js` twice, which makes the code behave differently compared to when using native ES modules.
+Parcel includes `obj.js` only in the first script, other scripts in the same HTML file access the shared module from the other script(s).

--- a/tests/code-splitting/subtests/multi-entry/parcel/package.json
+++ b/tests/code-splitting/subtests/multi-entry/parcel/package.json
@@ -3,6 +3,6 @@
     "build": "rm -rf .parcel-cache && parcel build src/index.html"
   },
   "dependencies": {
-    "parcel": "^2.0.0-alpha.3.2"
+    "parcel": "2.0.0-beta.3.1"
   }
 }


### PR DESCRIPTION
Closes https://github.com/GoogleChromeLabs/tooling.report/issues/435