### PR TITLE
Add Parcel plugin to avoid hashing of specific bundles

### DIFF
--- a/tests/hashing/subtests/avoid-hash/parcel/.parcelrc
+++ b/tests/hashing/subtests/avoid-hash/parcel/.parcelrc
@@ -1,0 +1,4 @@
+{
+  "extends": "@parcel/config-default",
+  "namers": ["parcel-namer-custom", "..."]
+}

--- a/tests/hashing/subtests/avoid-hash/parcel/index.md
+++ b/tests/hashing/subtests/avoid-hash/parcel/index.md
@@ -1,6 +1,10 @@
 ---
-result: partial
-issue: https://github.com/parcel-bundler/parcel/issues/4553
+result: pass
+issue:
+  - url: https://github.com/parcel-bundler/parcel/issues/4553
+    status: closed
 ---
 
-Parcel does not provide a way to control whether individual resources or bundles recieve hashed URLs. However, it does not include hashes in the URLs of HTML files and Service Workers by default.
+Parcel does not include hashes in the URLs of HTML files and Service Workers by default.
+
+Namer plugins control the naming of bundles and can also be used to selectively overriding names by returning `null` to defer to the default namer.

--- a/tests/hashing/subtests/avoid-hash/parcel/namer/index.js
+++ b/tests/hashing/subtests/avoid-hash/parcel/namer/index.js
@@ -1,0 +1,16 @@
+const { Namer } = require('@parcel/plugin');
+const path = require('path');
+
+module.exports = new Namer({
+  name({ bundle }) {
+    let mainEntry = bundle.getMainEntry();
+    if (
+      mainEntry != null &&
+      path.basename(mainEntry.filePath).includes('unhashed')
+    ) {
+      return path.basename(mainEntry.filePath);
+    }
+
+    return null;
+  },
+});

--- a/tests/hashing/subtests/avoid-hash/parcel/namer/package.json
+++ b/tests/hashing/subtests/avoid-hash/parcel/namer/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "parcel-namer-custom",
+  "version": "0.0.0",
+  "engines": {
+    "parcel": "^2.0.0"
+  },
+  "dependencies": {
+    "@parcel/plugin": "^2.0.0"
+  }
+}

--- a/tests/hashing/subtests/avoid-hash/parcel/package.json
+++ b/tests/hashing/subtests/avoid-hash/parcel/package.json
@@ -4,6 +4,7 @@
     "build": "rm -rf .parcel-cache && parcel build src/unhashed.html src/hashed.html"
   },
   "dependencies": {
-    "parcel": "^2.0.0"
+    "parcel": "^2.0.0",
+    "parcel-namer-custom": "link:./namer"
   }
 }


### PR DESCRIPTION
Related: https://github.com/parcel-bundler/parcel/issues/4553#issuecomment-656765668

> If I'm reading the docs correctly, it looks like v2.parceljs.org/plugin-system/namer/#overriding-names-for-specific-bundles would pass, as long as it can be used without publishing the plugin separately to npm.

The docs also list some recommendations for local plugins now: https://parceljs.org/features/plugins/#local-plugins
